### PR TITLE
Replaces tildes in filenames to underscores.

### DIFF
--- a/identifierconstants/IDStoryboardDumper.m
+++ b/identifierconstants/IDStoryboardDumper.m
@@ -28,7 +28,7 @@
 {
     self.skipClassDeclaration = YES;
     NSString *storyboardFilename = [[self.inputURL lastPathComponent] stringByDeletingPathExtension];
-    NSString *storyboardName = [storyboardFilename stringByReplacingOccurrencesOfString:@" " withString:@""];
+    NSString *storyboardName = [[storyboardFilename stringByReplacingOccurrencesOfString:@" " withString:@""] stringByReplacingOccurrencesOfString:@"~" withString:@"_"];
     
     self.className = [NSString stringWithFormat:@"%@%@StoryboardIdentifiers", self.classPrefix, storyboardName];
     NSError *error = nil;


### PR DESCRIPTION
Makes ``objc-identifierconstants`` work with tildes. Otherwise a filename like ``MainStoryboard~ipad.storyboard``  will generate identifiers in the form:
```objc
extern NSString *const R_MainStoryboard~ipadStoryboardWebSegueIdentifier;
```
Which don't compile.